### PR TITLE
Fix job now that non-retail versions of the plugins are on the same page

### DIFF
--- a/.github/workflows/LXP-R.yml
+++ b/.github/workflows/LXP-R.yml
@@ -58,9 +58,10 @@ jobs:
           curl -H 'Accept: application/json' \
             'https://www.curseforge.com/api/v1/mods/94855/files?pageIndex=0&pageSize=10&sort=dateCreated&sortDescending=true&removeAlphas=true' \
             -o curse-response.json
-          fileNameRaw=$(cat curse-response.json | jq -r '.data[0].fileName')
+          # 517 is the number curseforge uses to represent retail WoW. This jq command filters the versions of the addon to just the retail versions
+          fileNameRaw=$(cat curse-response.json | jq -r '.data | map(select(.gameVersionTypeIds | index(517))) | .[0].fileName')
           fileNameFixed=${fileNameRaw%.*}
-          echo "latest_curse_fileid=$(cat curse-response.json | jq -r '.data[0].id')" >> "$GITHUB_OUTPUT"
+          echo "latest_curse_fileid=$(cat curse-response.json | jq -r '.data | map(select(.gameVersionTypeIds | index(517))) | .[0].id')" >> "$GITHUB_OUTPUT"
           echo "latest_curse_filename=${fileNameFixed}" >> "$GITHUB_OUTPUT"
 
   # Download Job

--- a/.github/workflows/LXP-R.yml
+++ b/.github/workflows/LXP-R.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           echo "New version detected! $CURSE_FILENAME"
           tmp=${CURSE_FILEID:4:3}
-          echo https://mediafilez.forgecdn.net/files/${CURSE_FILEID:0:4}/${tmp#${tmp%%[!0]*}}/${fileNameFixed}.zip
+          echo https://mediafilez.forgecdn.net/files/${CURSE_FILEID:0:4}/${tmp#${tmp%%[!0]*}}/${CURSE_FILENAME}.zip
           # trim the leading 0s from the substring using ${tmp#${tmp%%[!0]*}}
           curl -O https://mediafilez.forgecdn.net/files/${CURSE_FILEID:0:4}/${tmp#${tmp%%[!0]*}}/${CURSE_FILENAME}.zip
       


### PR DESCRIPTION
The latest release in this repository has the classic version of the addon, which makes installations in WowUp fail. This PR seems to fix it. You can look at the latest job logs and release information in my fork: https://github.com/Markaronin/LeatrixPlus